### PR TITLE
Removed the escape chars from the . when using the StringUtils replace

### DIFF
--- a/drools-shapes/drools-shapes-generator-plugin/src/main/java/org/drools/shapes/MetaClassPlugin.java
+++ b/drools-shapes/drools-shapes-generator-plugin/src/main/java/org/drools/shapes/MetaClassPlugin.java
@@ -93,7 +93,7 @@ public class MetaClassPlugin extends MetadataPlugin {
             try {
                 File metaFile = new File( opt.targetDir.getPath().replace( "xjc", "java" ) +
                                           File.separator +
-                                          StringUtils.replace(keyed.getAttribute( "package" ), "\\.", File.separator ) +
+                                          StringUtils.replace(keyed.getAttribute( "package" ), ".", File.separator ) +
                                           File.separator +
                                           keyed.getAttribute( "name" ) +
                                           "_.java" );


### PR DESCRIPTION
Removed the escape chars from the . when using the StringUtils replace method in org.drools.shapes.MetaClassPlugin.
