### PR TITLE
Adjust handling of multiple @Display annotations in an @Evidence annotation.

### DIFF
--- a/drools-provenance/src/main/java/org/drools/beliefs/provenance/ProvenanceBeliefSetImpl.java
+++ b/drools-provenance/src/main/java/org/drools/beliefs/provenance/ProvenanceBeliefSetImpl.java
@@ -1,15 +1,6 @@
 package org.drools.beliefs.provenance;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-
 import com.clarkparsia.empire.annotation.RdfsClass;
-import java.util.concurrent.ConcurrentHashMap;
 import org.drools.beliefs.provenance.annotations.Display;
 import org.drools.beliefs.provenance.annotations.Evidence;
 import org.drools.beliefs.provenance.templates.TemplateRegistry;
@@ -21,45 +12,20 @@ import org.drools.core.common.InternalFactHandle;
 import org.drools.core.common.LogicalDependency;
 import org.drools.core.definitions.rule.impl.RuleImpl;
 import org.drools.core.factmodel.AnnotationDefinition;
-import org.drools.core.metadata.Don;
-import org.drools.core.metadata.DonLiteral;
-import org.drools.core.metadata.Identifiable;
-import org.drools.core.metadata.Lit;
-import org.drools.core.metadata.MetaCallableTask;
-import org.drools.core.metadata.MetadataContainer;
-import org.drools.core.metadata.Modify;
-import org.drools.core.metadata.ModifyLiteral;
-import org.drools.core.metadata.ModifyTask;
-import org.drools.core.metadata.NewInstance;
-import org.drools.core.metadata.Shed;
-import org.drools.core.metadata.WorkingMemoryTask;
-import org.drools.core.reteoo.RuleTerminalNodeLeftTuple;
+import org.drools.core.metadata.*;
 import org.drools.core.rule.Pattern;
 import org.drools.core.rule.RuleConditionElement;
 import org.drools.core.spi.Activation;
 import org.drools.core.util.Drools;
 import org.drools.semantics.Literal;
-import org.jboss.drools.provenance.AdditionImpl;
-import org.jboss.drools.provenance.AssertionImpl;
-import org.jboss.drools.provenance.DerogationImpl;
-import org.jboss.drools.provenance.Instance;
-import org.jboss.drools.provenance.InstanceImpl;
-import org.jboss.drools.provenance.Modification;
-import org.jboss.drools.provenance.Narrative;
-import org.jboss.drools.provenance.NarrativeImpl;
-import org.jboss.drools.provenance.Property;
-import org.jboss.drools.provenance.PropertyImpl;
-import org.jboss.drools.provenance.RecognitionImpl;
-import org.jboss.drools.provenance.RemovalImpl;
-import org.jboss.drools.provenance.RetractionImpl;
-import org.jboss.drools.provenance.Rule;
-import org.jboss.drools.provenance.RuleEngine;
-import org.jboss.drools.provenance.SettingImpl;
-import org.jboss.drools.provenance.TypificationImpl;
+import org.jboss.drools.provenance.*;
 import org.mvel2.templates.CompiledTemplate;
 import org.mvel2.templates.TemplateRuntime;
 import org.w3.ns.prov.Activity;
 import org.w3.ns.prov.ActivityImpl;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class ProvenanceBeliefSetImpl
         extends SimpleBeliefSet
@@ -244,14 +210,17 @@ public class ProvenanceBeliefSetImpl
 
         if ( evidenceDef != null && evidenceDef.getPropertyValue( "value" ) != null ) {
             AnnotationDefinition[] displays = (AnnotationDefinition[]) evidenceDef.getPropertyValue( "value" );
-            for ( AnnotationDefinition display : displays ) {
+            for ( int displayIndex = 0; displayIndex < displays.length; displayIndex++ ) {
+                AnnotationDefinition display = displays[displayIndex];
+
                 String type = (String) display.getPropertyValue( "type" );
 
                 String inlineTemplate = (String) display.getPropertyValue( "value" );
                 String templateRef = (String) display.getPropertyValue( "template" );
 
                 int index = ( (Pattern) rce ).getIndex();
-                CompiledTemplate compiled = TemplateRegistry.getInstance().compileAndCache( inlineTemplate != null ? ( rule.getName() + "_" + index ): templateRef,
+
+                CompiledTemplate compiled = TemplateRegistry.getInstance().compileAndCache( inlineTemplate != null ? ( rule.getName() + "_" + index + "_" + displayIndex ): templateRef,
                                                                                             inlineTemplate );
 
                 try {

--- a/drools-provenance/src/test/resources/testProvenanceMultipleDisplays.drl
+++ b/drools-provenance/src/test/resources/testProvenanceMultipleDisplays.drl
@@ -1,0 +1,26 @@
+package org.drools.beliefs.provenance;
+
+import org.drools.core.factmodel.traits.Entity;
+import com.foo.MySubKlass;
+import org.test.MyKlassImpl;
+import org.test.MyKlass;
+import org.test.MyKlass_;
+import com.foo.MySubKlass_;
+import static com.foo.MetaFactory.*;
+import static org.test.MetaFactory.*;
+import org.drools.core.metadata.Modify;
+import org.drools.beliefs.provenance.annotations.Evidence;
+import org.drools.beliefs.provenance.annotations.Display;
+import org.drools.core.common.InternalFactHandle;
+
+global java.util.List list;
+
+rule Test
+@Display
+no-loop
+dialect "mvel"
+when
+    $e : MyKlass() @Evidence( { @Display( type="1", value="Value 1" ), @Display( type="2", value="Value 2" ) } )
+then
+    insertLogical( MySubKlass_.donMySubKlass( $e ) );
+end


### PR DESCRIPTION
When an @Evidence annotation contains more than one @Display annotation, make sure the template cache takes that into account so that the correct template for each display is used.
