### PR TITLE
Removed the 'terms-metamodel' dependencyManagement entry with no version.

### DIFF
--- a/drools-shapes/drools-shapes-terms/pom.xml
+++ b/drools-shapes/drools-shapes-terms/pom.xml
@@ -43,10 +43,6 @@
 				<artifactId>cts2-service</artifactId>
 				<version>1.1.3-SNAPSHOT</version>
 			</dependency>
-			<dependency>
-				<groupId>edu.mayo.cts2</groupId>
-				<artifactId>terms-metamodel</artifactId>
-			</dependency>
 
 			<dependency>
 				<groupId>org.drools</groupId>


### PR DESCRIPTION
Removed the 'terms-metamodel' dependencyManagement entry with no version.
